### PR TITLE
maestro errors are non standard compared to wallet errors; just make …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **headless**: fixed the newline error occuring when making comments on threads
 - **app**: fixed the image size for threads both at the preview and modal
 - **app**: fixed text on buttons for the threadlist for dynamic screen sizes
+- **app**: fixed the cogno token not be reset when changing accounts
 
 
 ### Changed
@@ -45,6 +46,7 @@
 - **app**: changed cogno app is now just the forum
 - **app**: changed how the image is displayed if no content is present
 - **app**: changed the thread modal width from 3xl to 5xl
+- **app**: changed the error messages to lowercase
 
 ### Removed
 

--- a/app/components/Profile/Cogno.tsx
+++ b/app/components/Profile/Cogno.tsx
@@ -58,7 +58,7 @@ const Cogno: React.FC<CognoProps> = ({ network, wallet, cogno, refreshCogno }) =
 
     maestro.onTxConfirmed(message, async () => {
       refreshCogno();
-      setNotification('Transaction Is On-Chain');
+      setNotification('transaction is on-chain');
       setTitle('');
       setImage('');
       setDetails('');

--- a/app/components/Profile/transaction.ts
+++ b/app/components/Profile/transaction.ts
@@ -78,7 +78,7 @@ export const handleCognoTransaction = async (network: number | null,
     // console.error('Collateral Not Set');
     return {
       success: false,
-      message: 'Collateral Not Set'
+      message: 'collateral not set'
     };
   }
 

--- a/app/components/Thread/Comments.tsx
+++ b/app/components/Thread/Comments.tsx
@@ -36,7 +36,7 @@ export const Comments: React.FC<CommentProps> = ({ thread, network, wallet, refr
 
     maestro.onTxConfirmed(message, async () => {
       refreshThread();
-      setNotification('Transaction Is On-Chain');
+      setNotification('transaction is on-chain');
       // reset all the values
       setIsSubmitting(false);
       setComment('');

--- a/app/components/Thread/ThreadForm.tsx
+++ b/app/components/Thread/ThreadForm.tsx
@@ -34,7 +34,7 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
 
     maestro.onTxConfirmed(message, async () => {
       refreshThread();
-      setNotification('Transaction Is On-Chain');
+      setNotification('transaction is on-chain');
       // reset all the values
       setTitle('');
       setContent('');

--- a/app/components/Thread/ThreadModal.tsx
+++ b/app/components/Thread/ThreadModal.tsx
@@ -53,7 +53,7 @@ export const ThreadModal: React.FC<ThreadModalProps> = ({network, wallet, thread
 
     maestro.onTxConfirmed(message, async () => {
       refreshThread();
-      setNotification('Transaction Is On-Chain');
+      setNotification('transaction is on-chain');
       // reset all the values
       setIsSubmitting(false);
       setSubmittedTxHash('');
@@ -69,7 +69,6 @@ export const ThreadModal: React.FC<ThreadModalProps> = ({network, wallet, thread
     setShowSuccessLink(false);
     const result = await handleThreadDeletion(network, wallet, thread);
     if (result.success === false) {
-      // something failed so notify the user of the error message
       setNotification(result.message);
       setIsSubmitting(false);
 

--- a/app/components/Thread/transaction.ts
+++ b/app/components/Thread/transaction.ts
@@ -79,7 +79,7 @@ export const handleThreadCreation = async (
   if (collateralUTxOs.length === 0) {
     return {
       success: false,
-      message: 'Collateral Not Set'
+      message: 'collateral not set'
     };
   }
 
@@ -270,7 +270,7 @@ export const handleThreadDeletion = async (
   if (collateralUTxOs.length === 0) {
     return {
       success: false,
-      message: 'Collateral Not Set'
+      message: 'collateral not set'
     };
   }
 
@@ -441,7 +441,7 @@ export const handleCommentCreation = async (
   if (collateralUTxOs.length === 0) {
     return {
       success: false,
-      message: 'Collateral Not Set'
+      message: 'collateral not set'
     };
   }
 

--- a/app/pages/forum.tsx
+++ b/app/pages/forum.tsx
@@ -93,13 +93,16 @@ const Forum = () => {
           sessionStorage.setItem('cognoTokenName', tokenName);
           return foundUtxo;
         } else {
+          sessionStorage.setItem('cognoTokenName', "non existent token");
           return null;
         }
       } catch (error) {
+        sessionStorage.setItem('cognoTokenName', "non existent token");
         // something happened during the utxo fetch request
         return null;
       }
     } else {
+      sessionStorage.setItem('cognoTokenName', "non existent token");
       // bad network
       return null;
     }
@@ -170,7 +173,7 @@ const Forum = () => {
     if (network === networkFlag) {
       // this needs to display some alert
       const alertMsg = networkFlag === 1 ? 'Pre-Production' : 'Mainnet';
-      setNotification(`Network Must Be Set To ${alertMsg}!`);
+      setNotification(`network must be set to ${alertMsg}!`);
       const timer = setTimeout(() => {
         disconnect(); // Automatically disconnect
       }, 2718);


### PR DESCRIPTION
Wallet errors are fairly standardized but maestro errors are not. They all come from the single result.message object resulting in various types of error formats. Not too much can be done since each wallet and data provider has a different error format. The manual errors are now lowercase. The cogno token name is now reset to an invalid token name when switching accounts.