### PR TITLE
when profile or thread modal is open scrolling is turned off for the ackground

### DIFF
--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { CardanoWallet } from '../components/CardanoWallet';
 import { Profile } from '../components/Profile';
 import { BrowserWallet, UTxO } from '@meshsdk/core';
@@ -18,6 +18,18 @@ const NavBar: React.FC<NavBarProps> = ({ cogno, connected, network, wallet, refr
   const [isProfileModalOpen, setProfileModalOpen] = useState(false);
   const toggleProfileModal = useCallback(() => setProfileModalOpen(prev => !prev), []);
 
+  useEffect(() => {
+    if (isProfileModalOpen) {
+      document.body.classList.add('overflow-hidden');
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+
+    // Cleanup function to remove the class if the component unmounts
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, [isProfileModalOpen]);
 
   return (
     <nav className="light-bg py-1 w-full">

--- a/app/components/Thread/ThreadList.tsx
+++ b/app/components/Thread/ThreadList.tsx
@@ -18,9 +18,22 @@ const ThreadList: React.FC<ThreadListProps> = ({ network, wallet, threads, refre
   const [selectedThread, setSelectedThread] = useState<UTxO | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [searchInput, setSearchInput] = useState('');
-  const itemsPerPage = 25; // Number of items per page
+  const itemsPerPage = 10; // Number of items per page
   const maxPageButtons = 3; // Maximum number of page buttons to show at a time
   const cognoTokenName = sessionStorage.getItem('cognoTokenName');
+
+  useEffect(() => {
+    if (selectedThread) {
+      document.body.classList.add('overflow-hidden');
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+
+    // Cleanup function to remove the class if the component unmounts
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, [selectedThread]);
   
 
   useEffect(() => {


### PR DESCRIPTION
When scrolling on a  long thread or profile the background would scroll too. Very awkward experience. This turns that off when the profile or thread modal is opened then off when closed. Works as expected now.