### PR TITLE
removing grammerly plugin and fixing layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@
 - **app**: fixed the background scrolling issue for open modals
 - **app**: fixed blurred images not being centered and jumping in size
 - **cogno-project**: fixed cogno.forum readme link
+- **app**: fixed blurred images auto going into loading.. when refreshing the forum
 
 ### Changed
 
 - **app**: changed medium-text to dark-text
 - **app**: changed the blues around in the colors
 - **app**: changed the roundedness of the wallet connect button
+- **app**: changed inputs to disable grammerly automatically
+- **app**: changed help text to be always on the right hand side of the help icon
 
 ### Removed
 

--- a/app/components/BlurImage.tsx
+++ b/app/components/BlurImage.tsx
@@ -21,14 +21,13 @@ const parseImageUrl = (url: string): string => {
 const BlurImage: React.FC<BlurImageProps> = ({ imageUrl, width = 420, height = 420 }) => {
   const [isBlurred, setIsBlurred] = useState(true);
   const [loadedImageUrl, setLoadedImageUrl] = useState('/default-420x420.png'); // default placeholder for quicker loading times
-  const [isLoading, setIsLoading] = useState(false); // show a loading text when the image being lazy loaded
+  const [isLoadingImage, setisLoadingImage] = useState(false); // show a loading text when the image being lazy loaded
+
 
   useEffect(() => {
-    setIsLoading(true);
-
     const finalUrl = parseImageUrl(imageUrl);
-
     if (!isBlurred) {
+      setisLoadingImage(true);
       // Load the image when unblurring
       setLoadedImageUrl(finalUrl);
     } else {
@@ -38,11 +37,11 @@ const BlurImage: React.FC<BlurImageProps> = ({ imageUrl, width = 420, height = 4
   }, [isBlurred, imageUrl]);
 
   const handleImageLoad = () => {
-    setIsLoading(false);
+    setisLoadingImage(false);
   };
 
   const handleImageError = () => {
-    setIsLoading(false);
+    setisLoadingImage(false);
     setLoadedImageUrl('/error-420x420.png');
   };
 
@@ -68,14 +67,14 @@ const BlurImage: React.FC<BlurImageProps> = ({ imageUrl, width = 420, height = 4
       </div>
 
       {/* If the image is loading then show the loading text */}
-      {isLoading && (
+      {isLoadingImage && (
         <div className="absolute inset-0 flex items-center justify-center dark-bg bg-opacity-50 light-text">
           Loading...
         </div>
       )}
 
       {/* if blurred and not loading then show the click to unblur text */}
-      {isBlurred && !isLoading && (
+      {isBlurred && !isLoadingImage && (
         <div 
           className="absolute inset-0 flex items-center justify-center dark-bg bg-opacity-50 light-text cursor-pointer" 
           onClick={toggleBlur}

--- a/app/components/Profile/Cogno.tsx
+++ b/app/components/Profile/Cogno.tsx
@@ -116,6 +116,7 @@ const Cogno: React.FC<CognoProps> = ({ network, wallet, cogno, refreshCogno, onC
             autoComplete="off"
             maxLength={300}
             required
+            data-gramm="false"
           />
         </div>
         <div className="mb-2">
@@ -129,6 +130,7 @@ const Cogno: React.FC<CognoProps> = ({ network, wallet, cogno, refreshCogno, onC
             disabled={(!editMode && cogno !== null) || isSubmitting}
             autoComplete="off"
             maxLength={2048}
+            data-gramm="false"
           />
           {cogno && image !== '' &&
             (
@@ -148,6 +150,7 @@ const Cogno: React.FC<CognoProps> = ({ network, wallet, cogno, refreshCogno, onC
             disabled={(!editMode && cogno !== null) || isSubmitting}
             autoComplete="off"
             maxLength={40000}
+            data-gramm="false"
           />
         </div>
         <div className="flex flex-col items-center justify-between">

--- a/app/components/Thread/Comments.tsx
+++ b/app/components/Thread/Comments.tsx
@@ -90,6 +90,7 @@ export const Comments: React.FC<CommentProps> = ({ thread, network, wallet, refr
               autoComplete="off"
               maxLength={1000}
               disabled={isSubmitting}
+              data-gramm="false"
             ></textarea>
           </div>
           <button

--- a/app/components/Thread/ThreadForm.tsx
+++ b/app/components/Thread/ThreadForm.tsx
@@ -90,6 +90,7 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
           autoComplete="off"
           maxLength={300}
           disabled={isSubmitting}
+          data-gramm="false"
         />
       </div>
       <div className="m-2">
@@ -101,6 +102,7 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
           autoComplete="off"
           maxLength={40000}
           disabled={isSubmitting}
+          data-gramm="false"
         ></textarea>
       </div>
       <div className="m-2">
@@ -114,7 +116,7 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
             >
               <path d="M10 2a8 8 0 100 16 8 8 0 000-16zm.93 12.36h-1.85v-1.85h1.85v1.85zm0-4.71h-1.85v-4.71h1.85v4.71z" />
             </svg>
-            <div className="absolute bottom-0 left-0 transform translate-y-full light-bg dark-text text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 w-max">
+            <div className="absolute left-full top-1/2 transform -translate-y-1/2 ml-2 dark-bg light-text text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10 w-max">
               Categories help users filter threads.
             </div>
           </span>
@@ -150,8 +152,8 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
             >
               <path d="M10 2a8 8 0 100 16 8 8 0 000-16zm.93 12.36h-1.85v-1.85h1.85v1.85zm0-4.71h-1.85v-4.71h1.85v4.71z" />
             </svg>
-            <div className="absolute bottom-0 left-0 transform translate-y-full light-bg dark-text text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 w-max">
-              A image to be attached to the content of a thread.
+            <div className="absolute left-full top-1/2 transform -translate-y-1/2 ml-2 dark-bg light-text text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10 w-max">
+              The image attached to the content of a thread.
             </div>
           </span>
         </label>
@@ -163,6 +165,7 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
           autoComplete="off"
           maxLength={2000}
           disabled={isSubmitting}
+          data-gramm="false"
         />
       </div>
       <div className="m-2 flex items-center">
@@ -183,8 +186,8 @@ export const ThreadForm: React.FC<ThreadFormProps> = ({ network, wallet, refresh
             >
               <path d="M10 2a8 8 0 100 16 8 8 0 000-16zm.93 12.36h-1.85v-1.85h1.85v1.85zm0-4.71h-1.85v-4.71h1.85v4.71z" />
             </svg>
-            <div className="absolute bottom-0 left-0 transform translate-y-full light-bg dark-text text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 w-max">
-              Permanent threads can not be deleted and will be locked forever.
+            <div className="absolute left-full top-1/2 transform -translate-y-1/2 ml-2 dark-bg light-text text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10 w-max">
+              Permanent threads cannot be deleted and will be locked forever.
             </div>
           </span>
         </label>

--- a/app/components/Thread/ThreadList.tsx
+++ b/app/components/Thread/ThreadList.tsx
@@ -173,6 +173,7 @@ const ThreadList: React.FC<ThreadListProps> = ({ network, wallet, threads, refre
           onChange={handleSearchInputChange}
           className="border rounded dark-text py-2 ml-1 text-center w-4/12"
           autoComplete="off"
+          data-gramm="false"
         />
         <div className="w-1/12"></div> {/* Empty spacer */}
       </div>

--- a/app/pages/forum.tsx
+++ b/app/pages/forum.tsx
@@ -24,7 +24,7 @@ const Forum = () => {
   const [notification, setNotification] = useState<string>('');
   const [cogno, setCogno] = useState<null | UTxO>(null);
   const [threads, setThreads] = useState<UTxO[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingData, setisLoadingData] = useState(false);
 
   // Function to clear notification
   const clearNotification = () => setNotification('');
@@ -120,7 +120,7 @@ const Forum = () => {
 
   const getNetworkId = useCallback(async () => {
     if (wallet) {
-      setIsLoading(true);
+      setisLoadingData(true);
       // get the network and change address from the connected wallet
       const _network = await wallet.getNetworkId();
       const changeAddress = await wallet.getChangeAddress();
@@ -128,18 +128,18 @@ const Forum = () => {
       sessionStorage.setItem('changeAddress', changeAddress);
       sessionStorage.setItem('walletKeyHashes', JSON.stringify(serializeBech32Address(changeAddress)));
       setNetwork(_network);
-      setIsLoading(false);
+      setisLoadingData(false);
     }
   }, [wallet]);
 
   const refreshCognoAndThreads = async () => {
     // allows the threads and cognos to manually be updated
-    setIsLoading(true);
+    setisLoadingData(true);
     const _cogno = await findCogno();
     setCogno(_cogno);
     const _threads = await findThreads();
     setThreads(_threads);
-    setIsLoading(false);
+    setisLoadingData(false);
   };
 
   const refreshCogno = async () => {
@@ -194,7 +194,7 @@ const Forum = () => {
       {connected ? (
         network !== parseInt(process.env.NEXT_PUBLIC_NETWORK_FLAG!) ? (
           <div>
-            {isLoading ? (
+            {isLoadingData ? (
               <div className="flex items-center justify-center h-screen">
                 <p className="text-lg font-semibold light-text">Loading Cogno and Thread Data...</p>
               </div>


### PR DESCRIPTION
Help text should now only open to directly to the right of the help icon. Grammerly should be off on all inputs. Images during refresh should not get locked into the loading state.